### PR TITLE
get rid of unbounded maxOccurs, just use an integer

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -346,7 +346,7 @@ The `EBMLElementOccurrence` part is interpreted as an ABNF Variable Repetition. 
 
 The `EBMLMinOccurrence` represents the minimum number of occurrences of this `EBML Element` within its `Parent Element`. Each instance of the `Parent Element` MUST contain at least this many instances of this `EBML Element`. If the `EBML Element` has an empty `EBMLParentPath` then `EBMLMinOccurrence` refers to constraints on the occurrence of the `EBML Element` within the `EBML Document`. If `EBMLMinOccurrence` is not present then that `EBML Element` is considered to have a `EBMLMinOccurrence` value of 0. The semantic meaning of `EBMLMinOccurrence` within an `EBML Schema` is considered analogous to the meaning of `minOccurs` within an `XML Schema`. `EBML Elements` with `EBMLMinOccurrence` set to "1" that also have a `default` value (see [default](#default)) declared are not REQUIRED to be stored but are REQUIRED to be interpreted, see [Note on the Use of default attributes to define Mandatory EBML Elements](#note-on-the-use-of-default-attributes-to-define-mandatory-ebml-elements). An `EBML Element` defined with a `EBMLMinOccurrence` value greater than zero is called a `Mandatory EBML Element`.
 
-The `EBMLMaxOccurrence` represents the maximum number of occurrences of this `EBML Element` within its `Parent Element`. Each instance of the `Parent Element` MUST contain at most this many instances of this `EBML Element`. If the `EBML Element` has an empty `EBMLParentPath` then `EBMLMaxOccurrence` refers to constraints on the occurrence of the `EBML Element` within the `EBML Document`. If `EBMLMaxOccurrence` is not present then that `EBML Element` is considered to have an unbounded `EBMLMaxOccurrence` value. The semantic meaning of `EBMLMaxOccurrence` within an `EBML Schema path` is considered analogous to the meaning of `maxOccurs` within an `XML Schema`.
+The `EBMLMaxOccurrence` represents the maximum number of occurrences of this `EBML Element` within its `Parent Element`. Each instance of the `Parent Element` MUST contain at most this many instances of this `EBML Element`. If the `EBML Element` has an empty `EBMLParentPath` then `EBMLMaxOccurrence` refers to constraints on the occurrence of the `EBML Element` within the `EBML Document`. If `EBMLMaxOccurrence` is not present then that `EBML Element` is considered to have no maximum occurrence. The semantic meaning of `EBMLMaxOccurrence` within an `EBML Schema path` is considered analogous to the meaning of `maxOccurs` within an `XML Schema`.
 
 The `VariableParentOccurrence` part is interpreted as an ABNF Variable Repetition. The repetition amounts correspond to the amount of unspecified `Parent Element` levels there can be between the `EBMLFixedParent` and the actual `EBMLElementPath`.
 
@@ -368,7 +368,7 @@ The `minOccurs` attribute is OPTIONAL. If the `minOccurs` attribute is not prese
 
 An integer expressing the maximum number of occurrences of this `EBML Element` within its `Parent Element`. The `maxOccurs` value MUST be equal to the `EBMLMaxOccurrence` value of the `path`.
 
-The `maxOccurs` attribute is OPTIONAL. If the `maxOccurs` attribute is not present then that `EBML Element` is considered to have a maxOccurs value of 1.
+The `maxOccurs` attribute is OPTIONAL. If the `maxOccurs` attribute is not present then that `EBML Element` is considered to have no maximum occurrence, similar to `unbounded` in the XML world.
 
 #### range
 
@@ -448,8 +448,7 @@ The `type` attribute is OPTIONAL.
   <documentation lang="en" type="definition">Container of data and
   attributes representing one or many files.</documentation>
  </element>
- <element name="File" path="1*(\Files\File)" id="0x6146" type="master" minOccurs="1"
-  maxOccurs="unbounded">
+ <element name="File" path="1*(\Files\File)" id="0x6146" type="master" minOccurs="1">
   <documentation lang="en" type="definition">An attached file.</documentation>
  </element>
  <element name="FileName" path="1*1(\Files\File\FileName)" id="0x614E" type="utf-8"
@@ -702,8 +701,6 @@ path: `*((*\)\Void)`
 id: `0xEC`
 
 minOccurs: 0
-
-maxOccurs: unbounded
 
 type: Binary
 


### PR DESCRIPTION
As discussed on CELLAR unbounded is no longer a valid value. It should become the norm if the value is missing.
