### PR TITLE
set docType and readDocType to not 0 range

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -649,6 +649,8 @@ minOccurs: 1
 
 maxOccurs: 1
 
+range: not 0
+
 default: 1
 
 type: Unsigned Integer
@@ -666,6 +668,8 @@ id `0x4285`
 minOccurs: 1
 
 maxOccurs: 1
+
+range: not 0
 
 default: 1
 


### PR DESCRIPTION
As these elements are defined as `minver=1`, a `0` value is invalid.

partly addresses https://github.com/Matroska-Org/ebml-specification/issues/157