### PR TITLE
escape xml elements in sectional headers

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -343,11 +343,11 @@ The `EBML Schema` MUST document all Elements of the `EBML Body`. The `EBML Schem
 
 An `EBML Schema` MAY constrain the use of `EBML Header Elements` (see [EBML Header Elements](#ebml-header-elements)) by adding or constraining that Element's `range` attribute. For example, an `EBML Schema` MAY constrain the `EBMLMaxSizeLength` to a maximum value of `8` or MAY constrain the `EBMLVersion` to only support a value of `1`. If an `EBML Schema` adopts the `EBML Header Element` as-is, then it is not REQUIRED to document that Element within the `EBML Schema`. If an `EBML Schema` constrains the range of an `EBML Header Element`, then that `Element` MUST be documented within an `<element>` node of the `EBML Schema`. This document provides an example of an `EBML Schema`, see [EBML Schema Example](#ebml-schema-example).
 
-### <EBMLSchema> Element
+### \<EBMLSchema> Element
 
 As an XML Document, the `EBML Schema` MUST use `<EBMLSchema>` as the top level element. The `<EBMLSchema>` element MAY contain `<element>` sub-elements.
 
-### <EBMLSchema> Attributes
+### \<EBMLSchema> Attributes
 
 Within an `EBML Schema` the `<EBMLSchema>` element uses the following attributes:
 
@@ -363,13 +363,13 @@ The `version` lists an incremental non-negative integer that specifies the versi
 
 The `version` attribute is REQUIRED within the `<EBMLSchema>` Element.
 
-### <element> Element
+### \<element> Element
 
 Each `<element>` defines one `EBML Element` through the use of several attributes that are defined in [EBML Schema Element Attributes](#ebmlschema-attributes). `EBML Schemas` MAY contain additional attributes to extend the semantics but MUST NOT conflict with the definitions of the `<element>` attributes defined within this document.
 
 The `<element>` nodes contain a description of the meaning and use of the `EBML Element` stored within one or many `<documentation>` sub-elements and zero or one `<restriction>` sub-element. All `<element>` nodes MUST be sub-elements of the `<EBMLSchema>`.
 
-### <element> Attributes
+### \<element> Attributes
 
 Within an `EBML Schema` the `<element>` uses the following attributes to define an `EBML Element`:
 
@@ -496,11 +496,11 @@ The `maxver` (maximum version) attribute stores a non-negative integer that repr
 
 The `maxver` attribute is OPTIONAL. If the `maxver` attribute is not present then the `EBML Element` has a maximum version equal to the value stored in the `version` attribute of `<EBMLSchema>`.
 
-### <documentation> Element
+### \<documentation> Element
 
 The `<documentation>` element provides additional information about the `EBML Element`.
 
-### <documentation> Attributes
+### \<documentation> Attributes
 
 #### lang
 
@@ -514,15 +514,15 @@ A `type` attribute distinguishes the meaning of the documentation. Values for th
 
 The `type` attribute is OPTIONAL.
 
-### <restriction> Element
+### \<restriction> Element
 
 The `<restriction>` element provides information about restrictions to the allowable values for the `EBML Element` which are listed in `<enum>` elements.
 
-### <enum> Element
+### \<enum> Element
 
 The `<enum>` element stores a list of values allowed for storage in the `EBML Element`. The values MUST match the `type` of the `EBML Element` (for example `<enum value="Yes">` cannot be a valid value for a `EBML Element` that is defined as an unsigned integer). An `<enum>` element MAY also store `<documentation>` elements to further describe the `<enum>`.
 
-### <enum> Attributes
+### \<enum> Attributes
 
 #### label
 


### PR DESCRIPTION
otherwise the value is dropped altogether when the output docs are rendered