### PR TITLE
rename the type parameter of the documentation in schema to "purpose"

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -52,6 +52,6 @@
       <xsd:any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="lang"/>
-    <xsd:attribute name="type"/>
+    <xsd:attribute name="purpose"/>
   </xsd:complexType>
 </xsd:schema>

--- a/specification.markdown
+++ b/specification.markdown
@@ -502,11 +502,11 @@ A `lang` attribute which is set to the [@!RFC5646] value of the language of the 
 
 The `lang` attribute is OPTIONAL.
 
-#### type
+#### purpose
 
-A `type` attribute distinguishes the meaning of the documentation. Values for the `<documentation>` sub-element's `type` attribute MUST include one of the following: `definition`, `rationale`, `usage notes`, and `references`.
+A `purpose` attribute distinguishes the meaning of the documentation. Values for the `<documentation>` sub-element's `purpose` attribute MUST include one of the following: `definition`, `rationale`, `usage notes`, and `references`.
 
-The `type` attribute is OPTIONAL.
+The `purpose` attribute is OPTIONAL.
 
 ### \<restriction> Element
 


### PR DESCRIPTION
I'm not too happy about the name.