### PR TITLE
fix the range of the four octets EBML IDs

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -888,7 +888,7 @@ The VINT Data value of three-octet Element IDs MUST be between 0x4001 and 0x1FFF
 
 The numbers 0x1FFFFF and 0x200000 are RESERVED.
 
-Four octet Element IDs are numbers between 0x2000001 and 0xFFFFFFE. Four octet Element IDs are somewhat special in that they are useful for resynchronizing to major structures in the event of data corruption or loss. As such four octet Element IDs are split into two categories. Four octet Element IDs whose lower three octets (as encoded) would make printable 7-bit ASCII values (0x20 to 0x7F) MUST be allocated by the "Specification Required" policy. Sequential allocation of values is not required: specifications SHOULD include a specific request, and are encouraged to do early allocations.
+Four octet Element IDs are numbers between 0x101FFFFF and 0x1FFFFFFE. Four octet Element IDs are somewhat special in that they are useful for resynchronizing to major structures in the event of data corruption or loss. As such four octet Element IDs are split into two categories. Four octet Element IDs whose lower three octets (as encoded) would make printable 7-bit ASCII values (0x20 to 0x7F) MUST be allocated by the "Specification Required" policy. Sequential allocation of values is not required: specifications SHOULD include a specific request, and are encouraged to do early allocations.
 
 To be clear about the above category: four octet Element IDs always start with hex 0x10 to 0x1F, and that octet may be chosen so that the entire number has some desirable property, such as a specific CRC. The other three octets, when ALL having values between 0x21 (33, ASCII !) and 0x7E (126, ASCII ~), fall into this category.
 


### PR DESCRIPTION
The range is wrong, it starts with the first `VINT_DATA` value after the three octet IDs, and is actually both with 4 octets.

Related to #230