### PR TITLE
make the purpose element mandatory in the documentation Schema element

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -52,6 +52,15 @@
       <xsd:any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="lang"/>
-    <xsd:attribute name="purpose" use="required"/>
+    <xsd:attribute name="purpose" use="required">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="definition"/>
+          <xsd:enumeration value="rationale"/>
+          <xsd:enumeration value="references"/>
+          <xsd:enumeration value="usage notes"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
   </xsd:complexType>
 </xsd:schema>

--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -52,6 +52,6 @@
       <xsd:any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
     <xsd:attribute name="lang"/>
-    <xsd:attribute name="purpose"/>
+    <xsd:attribute name="purpose" use="required"/>
   </xsd:complexType>
 </xsd:schema>

--- a/specification.markdown
+++ b/specification.markdown
@@ -536,7 +536,7 @@ The lang attribute is OPTIONAL.
 
 A purpose attribute distinguishes the meaning of the documentation. Values for the <documentation> sub-element's purpose attribute MUST include one of the following: `definition`, `rationale`, `usage notes`, and `references`.
 
-The purpose attribute is OPTIONAL.
+The purpose attribute is REQUIRED.
 
 ### \<restriction> Element
 


### PR DESCRIPTION
Otherwise we need to define how to interpret the <documentation> tag if it's
not present.