### PR TITLE
Add ebml extension element

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -28,6 +28,8 @@
         minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="restriction" type="restrictionType"
         minOccurs="0" maxOccurs="1"/>
+      <xs:element name="extension" type="extensionType"
+        minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attribute name="name" use="required"/>
     <xs:attribute name="path" use="required"/>
@@ -49,6 +51,15 @@
       <xs:element name="enum" type="enumType" minOccurs="0"
         maxOccurs="unbounded"/>
     </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="extensionType">
+    <xs:sequence>
+      <xs:any processContents="skip"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="type" use="required"/>
+    <xs:anyAttribute processContents="skip"/>
   </xs:complexType>
 
   <xs:complexType name="enumType">

--- a/specification.markdown
+++ b/specification.markdown
@@ -312,7 +312,7 @@ The version attribute is REQUIRED within the `<EBMLSchema>` Element.
 
 Each `<element>` defines one EBML Element through the use of several attributes that are defined in [EBML Schema Element Attributes](#ebmlschema-attributes). EBML Schemas MAY contain additional attributes to extend the semantics but MUST NOT conflict with the definitions of the `<element>` attributes defined within this document.
 
-The `<element>` nodes contain a description of the meaning and use of the EBML Element stored within one or more `<documentation>` sub-elements, optional `<implementation_note>` sub-elements, and zero or one `<restriction>` sub-element. All `<element>` nodes MUST be sub-elements of the `<EBMLSchema>`.
+The `<element>` nodes contain a description of the meaning and use of the EBML Element stored within one or more `<documentation>` sub-elements, followed by optional `<implementation_note>` sub-elements, followed by zero or one `<restriction>` sub-element, followed by optional `<extension>` sub-elements. All `<element>` nodes MUST be sub-elements of the `<EBMLSchema>`.
 
 ### \<element> Attributes
 
@@ -509,6 +509,18 @@ The label attribute is OPTIONAL.
 The value represents data that MAY be stored within the EBML Element.
 
 The value attribute is REQUIRED.
+
+### \<extension> Element
+
+ The `<extension>` element provides an unconstained element to contain information about the associated EBML `<element>` which is undefined by this document but MAY be defined by the associated EBML Document Type. The `<extension>` element MUST contain a `type` attribute and also MAY contain any other attribute or sub-element as long as the EBML Schema remains as a well-formed XML Document. All `<extension>` elements MUST be sub-elements of the `<element>`.
+
+### \<extension> Attributes
+
+#### type
+
+The type attribute should reference a name or identifier of the project or authority associated with the contents of the `<extension>` element.
+
+The type attribute is REQUIRED.
 
 ### XML Schema for EBML Schema
 


### PR DESCRIPTION
As discussed in the cellar meeting. This subelement would allow a way to store webm data, cppname, etc without mixed such extensions with the rest of the element definition.

So in Matroska's EBML Schema:

```xml
<element name="AttachmentLink" path="0*1(\Segment\Tracks\TrackEntry\AttachmentLink)" cppname="TrackAttachmentLink" id="0x7446" type="uinteger" maxOccurs="1" minver="1" maxver="3" webm="0" range="not 0">
  <documentation lang="en">The UID of an attachment that is used by this codec.</documentation>
</element>
```
would become
```xml
<element name="AttachmentLink" path="0*1(\Segment\Tracks\TrackEntry\AttachmentLink)" id="0x7446" type="uinteger" maxOccurs="1" minver="1" maxver="3" range="not 0">
  <documentation lang="en">The UID of an attachment that is used by this codec.</documentation>
  <extension cppname="TrackAttachmentLink" webm="0"/>
</element>
```

This makes it a lot easier to have a valid EBML Schema for Matroska.