### PR TITLE
EBML Schema example: fix the documentation 'purpose' attribute

### DIFF
--- a/ebml_schema_example.xml
+++ b/ebml_schema_example.xml
@@ -10,39 +10,39 @@
    type="uinteger"/>
  <!-- Root Element-->
  <element name="Files" path="*1(\Files)" id="0x1946696C" type="master">
-  <documentation lang="en" type="definition">Container of data and
+  <documentation lang="en" purpose="definition">Container of data and
   attributes representing one or many files.</documentation>
  </element>
  <element name="File" path="1*(\Files\File)" id="0x6146" type="master"
    minOccurs="1">
-  <documentation lang="en" type="definition">
+  <documentation lang="en" purpose="definition">
     An attached file.
   </documentation>
  </element>
  <element name="FileName" path="1*1(\Files\File\FileName)"
    id="0x614E" type="utf-8"
    minOccurs="1">
-  <documentation lang="en" type="definition">
+  <documentation lang="en" purpose="definition">
     Filename of the attached file.
   </documentation>
  </element>
  <element name="MimeType" path="1*1(\Files\File\MimeType)"
    id="0x464D" type="string"
      minOccurs="1">
-  <documentation lang="en" type="definition">
+  <documentation lang="en" purpose="definition">
     MIME type of the file.
   </documentation>
  </element>
  <element name="ModificationTimestamp"
    path="1*1(\Files\File\ModificationTimestamp)" id="0x4654"
    type="date" minOccurs="1">
-  <documentation lang="en" type="definition">
+  <documentation lang="en" purpose="definition">
     Modification timestamp of the file.
   </documentation>
  </element>
  <element name="Data" path="1*1(\Files\File\Data)" id="0x4664" 
    type="binary" minOccurs="1">
-  <documentation lang="en" type="definition">
+  <documentation lang="en" purpose="definition">
     The data of the file.
   </documentation>
  </element>


### PR DESCRIPTION
Renamed since 283019746b5375e45a668bc1937323415d6ccb81

Now validate with `EBMLSchema.xsd` after the change in d50d5509b6824d94e4443f785e8ff1829ab8b789.