### PR TITLE
clarify value of default

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -450,7 +450,9 @@ The length attribute is OPTIONAL. If the length attribute is not present for tha
 
 #### default
 
-If an Element is mandatory (has a EBMLMinOccurrence value greater than zero) but not written within its Parent Element or stored as an Empty Element, then the EBML Reader of the EBML Document MUST semantically interpret the EBML Element as present with this specified default value for the EBML Element. EBML Elements that are Master Elements MUST NOT declare a default value. EBML Elements with a minOccurs value greater than 1 MUST NOT declare a default value.
+If an Element is mandatory (has a EBMLMinOccurrence value greater than zero) but not written within its Parent Element or stored as an Empty Element, then the EBML Reader of the EBML Document MUST semantically interpret the EBML Element as present with this specified default value for the EBML Element.
+EBML Elements that are Master Elements MUST NOT declare a default value.
+EBML Elements with a minOccurs value greater than 1 MUST NOT declare a default value.
 
 The default attribute is OPTIONAL.
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -451,6 +451,7 @@ The length attribute is OPTIONAL. If the length attribute is not present for tha
 #### default
 
 If an Element is mandatory (has a EBMLMinOccurrence value greater than zero) but not written within its Parent Element or stored as an Empty Element, then the EBML Reader of the EBML Document MUST semantically interpret the EBML Element as present with this specified default value for the EBML Element.
+An unwritten mandatory Element with a declared default value is semantically to that Element if written with the default value stored as the Element Data.
 EBML Elements that are Master Elements MUST NOT declare a default value.
 EBML Elements with a minOccurs value greater than 1 MUST NOT declare a default value.
 


### PR DESCRIPTION
Along with https://github.com/cellar-wg/matroska-specification/pull/272, this should resolve https://github.com/cellar-wg/ebml-specification/issues/224.

In other words, if you have the schema say:

```
<element name="OutputSamplingFrequency" default="SamplingFrequency"/>
```

and the file says
```xml
<SamplingFrequency>44100</SamplingFrequency>
```

then the meaning should be:
```xml
<SamplingFrequency>44100</SamplingFrequency>
<OutputSamplingFrequency>SamplingFrequency</OutputSamplingFrequency>
```

and not
```xml
<SamplingFrequency>44100</SamplingFrequency>
<OutputSamplingFrequency>44100</OutputSamplingFrequency>
```

So the default attribute should store what would be given by interpreting what the EBML Data of the unstored Element should be, and not a reference to another element. However, default values can be made to be associated with a related Element via an implementation_note.