### PR TITLE
bump to version 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 $(info RFC rendering has been tested with mmark version 2.1.1 and xml2rfc 2.30.0, please ensure these are installed and recent enough.)
 
-VERSION := 13
+VERSION := 14
 STATUS := draft-
 OUTPUT := $(STATUS)ietf-cellar-ebml-$(VERSION)
 

--- a/rfc_frontmatter.markdown
+++ b/rfc_frontmatter.markdown
@@ -10,7 +10,7 @@ keyword = [""]
 name = "Internet-Draft"
 stream = "IETF"
 status = "standard"
-value = "draft-ietf-cellar-ebml-13"
+value = "draft-ietf-cellar-ebml-14"
 
 [[author]]
 initials="S."


### PR DESCRIPTION
I suggest to merge https://github.com/cellar-wg/ebml-specification/pull/289, then we can push the release of version 13 to the datatracker (version 12 is invalid with line length).