### PR TITLE
don't make EBML too generic

### DIFF
--- a/rfc_frontmatter.markdown
+++ b/rfc_frontmatter.markdown
@@ -36,6 +36,6 @@ fullname="Moritz Bunkus"
 
 .# Abstract
 
-This document defines the Extensible Binary Meta Language (EBML) format as a generalized file format for any type of data in a hierarchical form. EBML is designed as a binary equivalent to XML and uses a storage-efficient approach to build nested Elements with identifiers, lengths, and values. Similar to how an XML Schema defines the structure and semantics of an XML Document, this document defines how EBML Schemas are created to convey the semantics of an EBML Document.
+This document defines the Extensible Binary Meta Language (EBML) format as a general purpose audio/video container format. EBML is designed as a binary equivalent to XML and uses a storage-efficient approach to build nested Elements with identifiers, lengths, and values. Similar to how an XML Schema defines the structure and semantics of an XML Document, this document defines how EBML Schemas are created to convey the semantics of an EBML Document.
 
 {mainmatter}

--- a/rfc_frontmatter.markdown
+++ b/rfc_frontmatter.markdown
@@ -36,6 +36,6 @@ fullname="Moritz Bunkus"
 
 .# Abstract
 
-This document defines the Extensible Binary Meta Language (EBML) format as a general purpose audio/video container format. EBML is designed as a binary equivalent to XML and uses a storage-efficient approach to build nested Elements with identifiers, lengths, and values. Similar to how an XML Schema defines the structure and semantics of an XML Document, this document defines how EBML Schemas are created to convey the semantics of an EBML Document.
+This document defines the Extensible Binary Meta Language (EBML) format as a binary container format designed for audio/video storage. EBML is designed as a binary equivalent to XML and uses a storage-efficient approach to build nested Elements with identifiers, lengths, and values. Similar to how an XML Schema defines the structure and semantics of an XML Document, this document defines how EBML Schemas are created to convey the semantics of an EBML Document.
 
 {mainmatter}


### PR DESCRIPTION
Its main goal is audio/video storage

Fixes #304 

I did not change the text in the main document which seems to be OK as we already state it's for audio/video:

```The goal of this document is to define a generic, binary, space-efficient format that can be used to define more complex formats using an EBML Schema. EBML is used by the multimedia container, Matroska [Matroska]. The applicability of EBML for other use cases is beyond the scope of this document.```