### PR TITLE
UTF-8 strings with NULL must still be valid UTF-8

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -1010,7 +1010,7 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 
 Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
 An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
-An UTF-8 string with Null octets at the end MUST be a valid UTF-8 string. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
+A UTF-8 string with Null octets at the end MUST be a valid UTF-8 string. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
 A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 
 [@tableNullOctetSemantics] shows examples of semantics and validation for the use of Null Octets. Values to represent Stored Values and the Semantic Meaning as represented as hexadecimal values.

--- a/specification.markdown
+++ b/specification.markdown
@@ -1010,7 +1010,7 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 
 Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
 An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
-An UTF-8 string with Null octets at the end MUST be a valid UTF-8 strings. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
+An UTF-8 string with Null octets at the end MUST be a valid UTF-8 string. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
 An EBML Reader MUST consider the value of the String Element or UTF-8 Element to be terminated upon the first read Null Octet and MUST ignore any data following the first Null Octet within that Element.
 A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -1008,7 +1008,10 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 
 # Terminating Elements
 
-Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator. An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED. An EBML Reader MUST consider the value of the String Element or UTF-8 Element to be terminated upon the first read Null Octet and MUST ignore any data following the first Null Octet within that Element. A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
+Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
+An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
+An EBML Reader MUST consider the value of the String Element or UTF-8 Element to be terminated upon the first read Null Octet and MUST ignore any data following the first Null Octet within that Element.
+A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 
 [@tableNullOctetSemantics] shows examples of semantics and validation for the use of Null Octets. Values to represent Stored Values and the Semantic Meaning as represented as hexadecimal values.
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -1011,7 +1011,6 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
 An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
 An UTF-8 string with Null octets at the end MUST be a valid UTF-8 string. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
-An EBML Reader MUST consider the value of the String Element or UTF-8 Element to be terminated upon the first read Null Octet and MUST ignore any data following the first Null Octet within that Element.
 A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 
 [@tableNullOctetSemantics] shows examples of semantics and validation for the use of Null Octets. Values to represent Stored Values and the Semantic Meaning as represented as hexadecimal values.

--- a/specification.markdown
+++ b/specification.markdown
@@ -1010,6 +1010,7 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 
 Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
 An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
+An UTF-8 string with Null octets at the end MUST be a valid UTF-8 strings. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
 An EBML Reader MUST consider the value of the String Element or UTF-8 Element to be terminated upon the first read Null Octet and MUST ignore any data following the first Null Octet within that Element.
 A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -1010,7 +1010,7 @@ If a Master Element contains more occurrences of a Child Element than permitted 
 
 Null Octets, which are octets with all bits set to zero, MAY follow the value of a String Element or UTF-8 Element to serve as a terminator.
 An EBML Writer MAY terminate a String Element or UTF-8 Element with Null Octets in order to overwrite a stored value with a new value of lesser length while maintaining the same Element Data Size (this can prevent the need to rewrite large portions of an EBML Document); otherwise the use of Null Octets within a String Element or UTF-8 Element is NOT RECOMMENDED.
-A UTF-8 string with Null octets at the end MUST be a valid UTF-8 string. In other words a Null octet cannot be found inside a multi-octet UTF-8 codepoint.
+The Element Data of a UTF-8 Element MUST be a valid UTF-8 string up to whichever comes first: the end of the Element or the first occurring Null octet. Within the Element Data of a String or UTF-8 Element, any Null octet itself and any following data within that Element SHOULD be ignored.
 A string value and a copy of that string value terminated by one or more Null Octets are semantically equal.
 
 [@tableNullOctetSemantics] shows examples of semantics and validation for the use of Null Octets. Values to represent Stored Values and the Semantic Meaning as represented as hexadecimal values.


### PR DESCRIPTION
Adressing a comment from Benjamin Kaduk https://mailarchive.ietf.org/arch/msg/cellar/epuOIwz8VXiu3V9-AbHNa7BRZjY