### PR TITLE
the EBMLParentPath may only contain the EBMLLastParent

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -387,7 +387,7 @@ The path attribute is REQUIRED.
 
 ```
 EBMLFullPath          = [EBMLParentPath] EBMLElementPath
-EBMLParentPath        = EBMLFixedParent EBMLLastParent
+EBMLParentPath        = [EBMLFixedParent] EBMLLastParent
 EBMLFixedParent       = *(EBMLPathAtom)
 EBMLElementPath       = EBMLPathAtom / EBMLPathAtomRecursive
 EBMLPathAtom          = PathDelimiter EBMLAtomName


### PR DESCRIPTION
Since they can't be empty and include a path that excluded \pathA\elt