### PR TITLE
add the missing recursive attribute in EBMLSchema.xsd

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -87,6 +87,8 @@
     </xs:attribute>
     <xs:attribute name="unknownsizeallowed" type="xs:boolean"
       default="false"/>
+    <xs:attribute name="recursive" type="xs:boolean"
+      default="false"/>
     <xs:attribute name="recurring" type="xs:boolean"
       default="false"/>
     <xs:attribute name="minver" default="1">


### PR DESCRIPTION
The attribute is defined in the specification for global elements.