### PR TITLE
add a more in-depth definition of an enum value

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -130,6 +130,7 @@
     </xs:sequence>
     <xs:attribute name="label"/>
     <xs:attribute name="value" use="required"/>
+    <xs:attribute name="definition"/>
   </xs:complexType>
 
   <xs:complexType name="documentationType" mixed="true">

--- a/specification.markdown
+++ b/specification.markdown
@@ -696,6 +696,14 @@ The value represents data that MAY be stored within the EBML Element.
 
 The value attribute is REQUIRED.
 
+#### definition
+
+Within an EBML Schema, the XPath of `@label` attribute is `/EBMLSchema/element/restriction/enum/@definition`.
+
+The definition provides a human readable explanation of the value of the `<enum>` with more information than the concise label attribute.
+
+The label attribute is OPTIONAL.
+
 ### \<extension> Element
 
 Within an EBML Schema, the XPath of `<extension>` attribute is `/EBMLSchema/element/extension`.


### PR DESCRIPTION
Following the LZO/compression values in Matroska, it seems we are missing an
element to give more information about values in an enum. In this case that
could be a (short) description of the algorithm, a link to a reference
implementation or the standard itself.

It may be too late to add to the spec. But if not that would be a welcome (tiny) addition.