### PR TITLE
turn "xsd" sourcecode tag into "xml" tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ $(OUTPUT).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.mar
 
 %.xml: %.md
 	$(MMARK) $< > $@
+	sed -i -e 's/<sourcecode type="xsd">/<sourcecode type="xml">/' $@
 
 %.html: %.xml
 	$(XML2RFC) --html $< -o $@


### PR DESCRIPTION
xsd is not supported and may not produce clean output:
https://www.rfc-editor.org/materials/sourcecode-types.txt

In the end the result is the same.

Fixes item 3.b of the rfc8794 AUTH48 email. It's not really an issue but IMO it's cleaner.