### PR TITLE
add some keywords to the document for easier searching in the RFCs

### DIFF
--- a/rfc_frontmatter.markdown
+++ b/rfc_frontmatter.markdown
@@ -4,7 +4,7 @@ abbrev = "EBML"
 ipr= "trust200902"
 area = "art"
 workgroup = "cellar"
-keyword = [""]
+keyword = ["binary","storage","xml","matroska","webm"]
 
 [seriesInfo]
 name = "Internet-Draft"


### PR DESCRIPTION
Item 1 of the AUTH48 email.

These words are not listed in the RFC text.