### PR TITLE
replace the custom Matroska reference to one found by xml2rfc

### DIFF
--- a/rfc_backmatter.markdown
+++ b/rfc_backmatter.markdown
@@ -57,16 +57,6 @@
   <format type='HTML' target='http://www.w3.org/TR/2018/SPSD-xhtml-basic-20180327' />
 </reference>
 
-<reference anchor="Matroska" target="https://datatracker.ietf.org/doc/draft-ietf-cellar-matroska/">
-  <front>
-    <title>Matroska Specifications</title>
-    <author>
-      <organization>IETF</organization>
-    </author>
-    <date year="2019" />
-  </front>
-</reference>
-
 <reference anchor="WebM" target="https://www.webmproject.org/docs/container/">
   <front>
     <title>WebM Container Guidelines</title>

--- a/specification.markdown
+++ b/specification.markdown
@@ -2,7 +2,7 @@
 
 EBML, short for Extensible Binary Meta Language, specifies a binary format aligned with octets (bytes) and inspired by the principle of XML (a framework for structuring data).
 
-The goal of this document is to define a generic, binary, space-efficient format that can be used to define more complex formats using an EBML Schema. EBML is used by the multimedia container, Matroska [@?Matroska]. The applicability of EBML for other use cases is beyond the scope of this document.
+The goal of this document is to define a generic, binary, space-efficient format that can be used to define more complex formats using an EBML Schema. EBML is used by the multimedia container, Matroska [@?I-D.ietf-cellar-matroska]. The applicability of EBML for other use cases is beyond the scope of this document.
 
 The definition of the EBML format recognizes the idea behind HTML and XML as a good one: separate structure and semantics allowing the same structural layer to be used with multiple, possibly widely differing semantic layers. Except for the EBML Header and a few Global Elements this specification does not define particular EBML format semantics; however this specification is intended to define how other EBML-based formats can be defined, such as the audio-video container formats Matroska and WebM [@?WebM].
 


### PR DESCRIPTION
Found in the AUTH48 RFC-editor XML file
https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-cellar-matroska.xml