### PR TITLE
Clarify the 0x is for notation, not storing

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -739,7 +739,7 @@ Within an EBML Schema, the XPath of the `@id` attribute is
 `/EBMLSchema/element/@id`.
 
 The Element ID is encoded as a Variable-Size Integer expressed in
-hexadecimal notation prefixed by a 0x that is read and stored in big-endian
+hexadecimal notation prefixed by a 0x; the Element ID is read and stored in big-endian
 order. To reduce the risk of false positives while parsing EBML Streams, the
 Element IDs of the Root Element and Top-Level Elements **SHOULD**
 be at least 4 octets in length. Element IDs defined for use at Root Level or

--- a/specification.markdown
+++ b/specification.markdown
@@ -738,9 +738,9 @@ resulting path, `\a\b\c\global`, has two EBMLPathAtom between
 Within an EBML Schema, the XPath of the `@id` attribute is
 `/EBMLSchema/element/@id`.
 
-The Element ID is encoded as a Variable-Size Integer expressed in
-hexadecimal notation prefixed by a 0x; the Element ID is read and stored in big-endian
-order. To reduce the risk of false positives while parsing EBML Streams, the
+The Element ID is encoded as a Variable-Size Integer. It is read and stored in big-endian
+order. In the EBML Schema it is expressed in
+hexadecimal notation prefixed by a 0x. To reduce the risk of false positives while parsing EBML Streams, the
 Element IDs of the Root Element and Top-Level Elements **SHOULD**
 be at least 4 octets in length. Element IDs defined for use at Root Level or
 directly under the Root Level **MAY** use shorter octet lengths to


### PR DESCRIPTION
Different text than suggested by the RFC editors.