### PR TITLE
clarify maxOccurs attribute value in specification

### DIFF
--- a/specification.markdown
+++ b/specification.markdown
@@ -789,8 +789,9 @@ The semantic meaning of `minOccurs` within an EBML Schema is analogous to the me
 Within an EBML Schema, the XPath of the `@maxOccurs` attribute is
 `/EBMLSchema/element/@maxOccurs`.
 
-`maxOccurs` is a nonnegative integer expressing the maximum permitted number
-of occurrences of this EBML Element within its Parent Element.
+`maxOccurs` is a nonnegative integer, or the term "unbounded" expressing
+the maximum permitted number of occurrences of this EBML Element within its
+Parent Element.
 
 Each instance of the Parent Element **MUST** contain at most
 this many instances of this EBML Element, including the unwritten mandatory
@@ -800,15 +801,18 @@ If the EBML Element has an empty EBMLParentPath, then `maxOccurs` refers to
 constraints on the occurrence of the EBML Element within the EBML
 Document.
 
-The `maxOccurs` attribute is **OPTIONAL**. If the `maxOccurs`
-attribute is not present, then there is no upper bound for the permitted
-number of occurrences of this EBML Element within its Parent Element or within
-the EBML Document, depending on whether or not the EBMLParentPath of the EBML Element
-is empty.
+If the value of `maxOccurs` is "unbounded", then there is no upper bound for the
+permitted number of occurrences of this EBML Element within its Parent Element
+or within the EBML Document, depending on whether or not the EBMLParentPath of
+the EBML Element is empty.
+
+The `maxOccurs` attribute is **OPTIONAL**. The default value of `maxOccurs`
+is "unbounded". There for, when `maxOccurs` attribute is not present the maximum
+occurence of this EBML Element is not limited.
 
 The semantic meaning of `maxOccurs` within an EBML Schema is analogous to the
-meaning of `maxOccurs` within an XML Schema; when it is not present, it's
-similar to xml:maxOccurs="unbounded" in an XML Schema.
+meaning of `maxOccurs` within an XML Schema. The only difference is their default
+value.
 
 #### range
 


### PR DESCRIPTION
The EBMLSchema definition for `maxOccurs` is about to change. This PR contains a specification change which clarifies the possible values of this attribute.

Related to #395 and #396 