### PR TITLE
add minver/maxver attributes to enum values

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -146,11 +146,12 @@
     </xs:sequence>
     <xs:attribute name="label"/>
     <xs:attribute name="value" use="required"/>
+    <xs:attribute name="minver"/>
   </xs:complexType>
 
   <xs:complexType name="documentationType" mixed="true">
     <xs:sequence>
-      <xs:element name="a"      type="xhtml:xhtml.a.type" 
+      <xs:element name="a"      type="xhtml:xhtml.a.type"
         minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="br"     type="xhtml:xhtml.br.type"
         minOccurs="0" maxOccurs="unbounded"/>

--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -147,6 +147,7 @@
     <xs:attribute name="label"/>
     <xs:attribute name="value" use="required"/>
     <xs:attribute name="minver"/>
+    <xs:attribute name="maxver"/>
   </xs:complexType>
 
   <xs:complexType name="documentationType" mixed="true">

--- a/update1/update1.markdown
+++ b/update1/update1.markdown
@@ -87,6 +87,23 @@ The `minver` attribute is **OPTIONAL**. If the `minver`
 attribute is not present, the enum's minimum version is the same as the
 EBML Element's minimum version this enum belongs to.
 
+## maxver Attribute
+
+A new attribute is added to the list of `<enum>` attributes found in [@?RFC8794, section 11.1.13].
+
+Within an EBML Schema, the XPath of the `@value` attribute is
+`/EBMLSchema/element/restriction/enum/@maxver`.
+
+The `maxver` (maximum version) attribute stores a nonnegative integer that
+represents the last or most recent version of the docType to support
+the enum value. `maxver` **MUST** be greater than or equal to
+the first version of the docType to support the enum value, whether it's set
+in the `minver` attribute of the enum or implied.
+
+The `maxver` attribute is **OPTIONAL**. If the `maxver`
+attribute is not present, the enum's maximum version is the same as the
+EBML Element's maximum version this enum belongs to.
+
 # Updated EBML Schema
 
 The following provides the updated XML Schema [@!XML-SCHEMA] of the EBML Schema

--- a/update1/update1.markdown
+++ b/update1/update1.markdown
@@ -70,6 +70,23 @@ The `added` attribute is **OPTIONAL** within the <EBMLSchema> Element and the EB
 If the `added` attribute is not present the element is considered to have always
 been present in `minver` [@!RFC8794, section 11.1.6.13] version of the format it's defined for.
 
+# New `<enum>` Attributes
+
+## minver Attribute
+
+A new attribute is added to the list of `<enum>` attributes found in [@?RFC8794, section 11.1.13].
+
+Within an EBML Schema, the XPath of the `@value` attribute is
+`/EBMLSchema/element/restriction/enum/@minver`.
+
+The `minver` (minimum version) attribute stores a nonnegative integer that
+represents the first version of the docType to support the enum value. The value
+**MUST** be greater than or equal to the EBML Element's minimum version ([@!RFC8794, section 11.1.6.13]) this enum belongs to.
+
+The `minver` attribute is **OPTIONAL**. If the `minver`
+attribute is not present, the enum's minimum version is the same as the
+EBML Element's minimum version this enum belongs to.
+
 # Updated EBML Schema
 
 The following provides the updated XML Schema [@!XML-SCHEMA] of the EBML Schema


### PR DESCRIPTION
This allows adding new enum values without forcing old readers to support them.

The explanation is copied from the minver attribute of "element"

This is necessary (IMO) to add new values like [zstd compression](https://github.com/ietf-wg-cellar/matroska-specification/pull/423)