### PR TITLE
generate a new document for corrections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-VERSION := 21
-STATUS := draft-
-OUTPUT := $(STATUS)ietf-cellar-ebml-$(VERSION)
+VERSION_EBML := 21
+STATUS_EBML := draft-
+OUTPUT_EBML := $(STATUS_EBML)ietf-cellar-ebml-$(VERSION_EBML)
+VERSION_CORRECTION := 01
+STATUS_CORRECTION := draft-
+OUTPUT_CORRECTION := $(STATUS_EBML)ietf-cellar-rfc8794-corrections-$(VERSION_CORRECTION)
 
 XML2RFC_CALL := xml2rfc
 MMARK_CALL := mmark
@@ -10,20 +13,26 @@ MMARK_CALL := mmark
 XML2RFC := $(XML2RFC_CALL) --v3
 MMARK := $(MMARK_CALL)
 
-all: $(OUTPUT).html $(OUTPUT).txt $(OUTPUT).xml
+all: ebml ebml_corrections
 	$(info RFC rendering has been tested with mmark version 2.2.8 and xml2rfc 2.46.0, please ensure these are installed and recent enough.)
 
-$(OUTPUT).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.markdown EBMLSchema.xsd ebml_schema_example.xml
-	cat rfc_frontmatter.markdown $< rfc_backmatter.markdown | sed "s/@BUILD_DATE@/$(shell date +'%F')/" > $(OUTPUT).md
+ebml: rfc8794.xml $(OUTPUT_EBML).html $(OUTPUT_EBML).txt $(OUTPUT_EBML).tmp_xml
+ebml_corrections: $(OUTPUT_CORRECTION).html $(OUTPUT_CORRECTION).txt $(OUTPUT_CORRECTION).tmp_xml
 
-%.xml: %.md
+$(OUTPUT_EBML).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.markdown EBMLSchema.xsd ebml_schema_example.xml
+	cat rfc_frontmatter.markdown $< rfc_backmatter.markdown | sed "s/@BUILD_DATE@/$(shell date +'%F')/" > $@
+
+$(OUTPUT_CORRECTION).md: corrections.markdown rfc_frontmatter_corrections.markdown rfc_backmatter_corrections.markdown EBMLSchema.xsd
+	cat rfc_frontmatter_corrections.markdown $< rfc_backmatter_corrections.markdown | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" -e "s/@BUILD_VERSION@/$(OUTPUT_CORRECTION)/" > $@
+
+%.tmp_xml: %.md
 	$(MMARK) $< > $@
-	sed -i -e 's/<sourcecode type="xsd">/<sourcecode type="xml">/' $@
 
-rfc8794.xml: $(OUTPUT).xml
+$(OUTPUT_EBML).xml: $(OUTPUT_EBML).tmp_xml
 	sed -e 's/<?xml version="1.0" encoding="utf-8"?>/<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">/' \
-	-e "s/docName=\"8794\"/docName=\"$(OUTPUT)\" sortRefs=\"true\"/" \
+	-e "s/docName=\"8794\"/docName=\"$(OUTPUT_EBML)\" sortRefs=\"true\"/" \
 	-e "s@\"http://www.w3.org/2001/XInclude\"@\"http://www.w3.org/2001/XInclude\" tocInclude=\"true\" symRefs=\"true\"@" \
+	-e 's/<sourcecode type="xsd">/<sourcecode type="xml">/' \
 	-e 's@<organization></organization>@@' \
 	-e 's@<street></street>@@' \
 	-e 's@<li>@<li><t>@' \
@@ -35,11 +44,31 @@ rfc8794.xml: $(OUTPUT).xml
 	$< | \
 	awk 1 RS='</t>\n</dd>' ORS='</dd>' | head -n -1 > $@
 
-%.html: rfc8794.xml
+$(OUTPUT_CORRECTION).xml: $(OUTPUT_CORRECTION).tmp_xml
+	sed -e 's/<?xml version="1.0" encoding="utf-8"?>/<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">/' \
+	-e "s/docName=\"87940\"/docName=\"$(OUTPUT_CORRECTION)\" sortRefs=\"true\"/" \
+	-e "s@\"http://www.w3.org/2001/XInclude\"@\"http://www.w3.org/2001/XInclude\" tocInclude=\"true\" symRefs=\"true\"@" \
+	-e 's/<sourcecode type="xsd">/<sourcecode type="xml">/' \
+	-e 's@<organization></organization>@@' \
+	-e 's@<street></street>@@' \
+	-e 's@<li>@<li><t>@' \
+	-e 's@</li>@</t>\n</li>@' \
+	-e 's@BCP 14@BCP\&nbsp;14@' \
+	-e 's@<dd><t>@<dd>@' \
+	-e 's@<date></date>@@' \
+	$< | \
+	awk 1 RS='</t>\n</dd>' ORS='</dd>' | head -n -1 > $@
+
+rfc8794.xml: $(OUTPUT_EBML).xml
+	cp $< $@
+
+%.html: %.xml
 	$(XML2RFC) --html $< -o $@
 
-%.txt: rfc8794.xml
+%.txt: %.xml
 	$(XML2RFC) $< -o $@
 
 clean:
-	rm -f $(OUTPUT).txt $(OUTPUT).html $(OUTPUT).md $(OUTPUT).xml
+	rm -f $(OUTPUT_EBML).html $(OUTPUT_EBML).txt $(OUTPUT_EBML).xml $(OUTPUT_EBML).tmp_xml $(OUTPUT_EBML).md
+	rm -f rfc8794.xml
+	rm -f $(OUTPUT_CORRECTION).html $(OUTPUT_CORRECTION).txt $(OUTPUT_CORRECTION).xml $(OUTPUT_CORRECTION).tmp_xml $(OUTPUT_CORRECTION).md

--- a/corrections.markdown
+++ b/corrections.markdown
@@ -1,0 +1,30 @@
+# `<EBMLSchema>` Namespace RFC
+
+The namespace URI for elements of the EBML Schema is a URN as defined by
+[@!RFC8141] instead of the deprecated [@!RFC2141].
+
+# All-zero ID's are allowed
+
+Matroska is using the `0x80` element ID so it **MUST**** be allowed in EBML as well.
+Here are the changes needed for this:
+
+- The bits of the VINT\_DATA component of the Element ID **MUST NOT** be all `1` values.
+All `0` values are now allowed.
+- One-octet Element IDs **MUST** be between 0x80 and 0xFE, rather than between 0x81 and 0xFE.
+- 0x80, 0x4000, 0x200000 and 0x10000000 are no longer RESERVED ID's.
+
+# DocTypeVersion Typos
+
+In sections 10.2, 15.1 and 15.2 of [@!RFC8794] the word `EBMLDocTypeVersion` is used where `DocTypeVersion`
+should have been used.
+
+# Revised XML Schema for EBML Schema
+
+The XML Schema for the EBML Schema had a few issues:
+
+- The embedded EBML Schema had the default value of the `maxOccurs` attribute set to `1` instead of `unbounded`.
+- The `unbounded` value was not legal for the `maxOccurs` attribute.
+
+Here is the revised version.
+
+<{{EBMLSchema.xsd}}

--- a/rfc_backmatter_corrections.markdown
+++ b/rfc_backmatter_corrections.markdown
@@ -1,0 +1,2 @@
+
+{backmatter}

--- a/rfc_frontmatter_corrections.markdown
+++ b/rfc_frontmatter_corrections.markdown
@@ -1,0 +1,43 @@
+%%%
+title = "Extensible Binary Meta Language: Corrections for RFC 8794"
+abbrev = "EBML"
+ipr= "trust200902"
+area = "art"
+submissiontype = "IETF"
+workgroup = "cellar"
+date = @BUILD_DATE@
+keyword = ["binary","storage","xml","matroska","webm"]
+
+[seriesInfo]
+name = "Internet-Draft"
+stream = "IETF"
+status = "standard"
+value = "@BUILD_VERSION@"
+
+[[author]]
+initials="S."
+surname="Lhomme"
+fullname="Steve Lhomme"
+[author.address]
+email="slhomme@matroska.org"
+
+[[author]]
+initials="D."
+surname="Rice"
+fullname="Dave Rice"
+[author.address]
+email="dave@dericed.com"
+
+[[author]]
+initials="M."
+surname="Bunkus"
+fullname="Moritz Bunkus"
+[author.address]
+email="moritz@bunkus.org"
+%%%
+
+.# Abstract
+
+This document adds some corrections to [@!RFC8794] which defines the Extensible Binary Meta Language (EBML) format.
+
+{mainmatter}


### PR DESCRIPTION
The format is simpler that the one in [RFC 8540](https://www.rfc-editor.org/rfc/rfc8540.html). If needed I can update the format.

We may also add `ebml.xml` as an annex, making it normative. But it's more work than necessary, possibly leading to new fixes...

Fixes #412 