### PR TITLE
fix Matroska draft reference

### DIFF
--- a/rfc_backmatter.markdown
+++ b/rfc_backmatter.markdown
@@ -44,6 +44,18 @@
   <seriesInfo name="ITU-T Recommendation" value="V.42" />
 </reference>
 
+<reference anchor="I-D.ietf-cellar-matroska">
+  <front>
+    <title>Matroska Media Container Format Specifications</title>
+    <author initials="S." surname="Lhomme" fullname="Steve Lhomme"> </author>
+    <author initials="M." surname="Bunkus" fullname="Moritz Bunkus"> </author>
+    <author initials="D." surname="Rice" fullname="Dave Rice"> </author>
+    <date month="October" day="09" year="2021"/>
+  </front>
+  <seriesInfo name="Internet-Draft" value="draft-ietf-cellar-matroska-08"/>
+  <format type="TXT" target="https://www.ietf.org/archive/id/draft-ietf-cellar-matroska-08.txt"/>
+</reference>
+
 <reference anchor="WebM" target="https://www.webmproject.org/docs/container/">
   <front>
     <title>WebM Container Guidelines</title>


### PR DESCRIPTION
`I-D.ietf-cellar-matroska` on an unpublished document doesn't work anymore.

I-D.draft-ietf-cellar-matroska or I-D.draft-ietf-cellar-matroska-07 should work
but they don't, xml2rfc doesn't find load the XML document that exists.

So we manually set a matching reference in the list of references.