### PR TITLE
rename the ZIP artifacts of IETF XMLs

### DIFF
--- a/.github/workflows/generate-rfcs.yaml
+++ b/.github/workflows/generate-rfcs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: XML Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ietf-xmls
+          name: ebml-ietf-xmls
           path: |
             rfc8794.xml
             draft-ietf-cellar-ebml-*.xml


### PR DESCRIPTION
This is the same name as the Matroska artifacts with the XML files.