### PR TITLE
Add a new document with the "added" attribute

### DIFF
--- a/EBMLSchema.xsd
+++ b/EBMLSchema.xsd
@@ -114,6 +114,13 @@
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>
+    <xs:attribute name="added" default="0">
+      <xs:simpleType>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
   </xs:complexType>
 
   <xs:complexType name="restrictionType">
@@ -176,6 +183,8 @@
               <xs:enumeration value="default"/>
               <xs:enumeration value="minver"/>
               <xs:enumeration value="maxver"/>
+              <xs:enumeration value="update"/>
+              <xs:enumeration value="added"/>
             </xs:restriction>
           </xs:simpleType>
         </xs:attribute>

--- a/EBMLSchema8794.xsd
+++ b/EBMLSchema8794.xsd
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="urn:ietf:rfc:8794"
+  targetNamespace="urn:ietf:rfc:8794"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  elementFormDefault="qualified" version="01">
+
+  <!-- for HTML in comments -->
+  <xs:import namespace="http://www.w3.org/1999/xhtml"
+    schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml11.xsd"/>
+
+  <xs:element name="EBMLSchema" type="EBMLSchemaType"/>
+
+  <xs:complexType name="EBMLSchemaType">
+    <xs:sequence>
+      <xs:element name="element" type="elementType"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="docType" use="required"/>
+    <xs:attribute name="version" use="required" type="xs:integer"/>
+    <xs:attribute name="ebml" type="xs:positiveInteger"
+      default="1"/>
+  </xs:complexType>
+
+  <xs:complexType name="elementType">
+    <xs:sequence>
+      <xs:element name="documentation" type="documentationType"
+        minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="implementation_note" type="noteType"
+        minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="restriction" type="restrictionType"
+        minOccurs="0" maxOccurs="1"/>
+      <xs:element name="extension" type="extensionType"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="[0-9A-Za-z.-]([0-9A-Za-z.-])*"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="path" use="required">
+      <!-- <xs:simpleType>
+        <xs:restriction base="xs:integer">
+          <xs:pattern value="[0-9]*\*[0-9]*()"/>
+        </xs:restriction>
+      </xs:simpleType> -->
+    </xs:attribute>
+    <xs:attribute name="id" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:pattern value="0x([0-9A-F][0-9A-F])+"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="minOccurs" default="0">
+      <xs:simpleType>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="maxOccurs" default="unbounded">
+      <xs:simpleType>
+        <xs:union>
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:minInclusive value="0"/>
+            </xs:restriction>
+          </xs:simpleType>
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="unbounded"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:union>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="range"/>
+    <xs:attribute name="length"/>
+    <xs:attribute name="default"/>
+    <xs:attribute name="type" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="integer"/>
+          <xs:enumeration value="uinteger"/>
+          <xs:enumeration value="float"/>
+          <xs:enumeration value="string"/>
+          <xs:enumeration value="date"/>
+          <xs:enumeration value="utf-8"/>
+          <xs:enumeration value="master"/>
+          <xs:enumeration value="binary"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="unknownsizeallowed" type="xs:boolean"
+      default="false"/>
+    <xs:attribute name="recursive" type="xs:boolean"
+      default="false"/>
+    <xs:attribute name="recurring" type="xs:boolean"
+      default="false"/>
+    <xs:attribute name="minver" default="1">
+      <xs:simpleType>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="maxver">
+      <xs:simpleType>
+        <xs:restriction base="xs:integer">
+          <xs:minInclusive value="0"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="restrictionType">
+    <xs:sequence>
+      <xs:element name="enum" type="enumType"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="extensionType">
+    <xs:sequence>
+      <xs:any processContents="skip"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="type" use="required"/>
+    <xs:anyAttribute processContents="skip"/>
+  </xs:complexType>
+
+  <xs:complexType name="enumType">
+    <xs:sequence>
+      <xs:element name="documentation" type="documentationType"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="label"/>
+    <xs:attribute name="value" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="documentationType" mixed="true">
+    <xs:sequence>
+      <xs:element name="a"      type="xhtml:xhtml.a.type" 
+        minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="br"     type="xhtml:xhtml.br.type"
+        minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="strong" type="xhtml:xhtml.strong.type"
+        minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="lang"/>
+    <xs:attribute name="purpose" use="required">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="definition"/>
+          <xs:enumeration value="rationale"/>
+          <xs:enumeration value="references"/>
+          <xs:enumeration value="usage notes"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="noteType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="note_attribute" use="required">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:enumeration value="minOccurs"/>
+              <xs:enumeration value="maxOccurs"/>
+              <xs:enumeration value="range"/>
+              <xs:enumeration value="length"/>
+              <xs:enumeration value="default"/>
+              <xs:enumeration value="minver"/>
+              <xs:enumeration value="maxver"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:attribute>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MMARK := $(MMARK_CALL)
 all: $(OUTPUT).html $(OUTPUT).txt $(OUTPUT).xml
 	$(info RFC rendering has been tested with mmark version 2.2.8 and xml2rfc 2.46.0, please ensure these are installed and recent enough.)
 
-$(OUTPUT).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.markdown EBMLSchema.xsd ebml_schema_example.xml
+$(OUTPUT).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.markdown EBMLSchema8794.xsd ebml_schema_example.xml
 	cat rfc_frontmatter.markdown $< rfc_backmatter.markdown | sed "s/@BUILD_DATE@/$(shell date +'%F')/" > $(OUTPUT).md
 
 %.xml: %.md

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION := 21
+VERSION_UPDATE1 := 00
 STATUS := draft-
 OUTPUT := $(STATUS)ietf-cellar-ebml-$(VERSION)
+OUTPUT_UPDATE1 := draft-ietf-cellar-ebml-update1-$(VERSION_UPDATE1)
 
 XML2RFC_CALL := xml2rfc
 MMARK_CALL := mmark
@@ -10,11 +12,15 @@ MMARK_CALL := mmark
 XML2RFC := $(XML2RFC_CALL) --v3
 MMARK := $(MMARK_CALL)
 
-all: $(OUTPUT).html $(OUTPUT).txt $(OUTPUT).xml
+all: $(OUTPUT).html $(OUTPUT).txt $(OUTPUT).xml $(OUTPUT_UPDATE1).html $(OUTPUT_UPDATE1).txt $(OUTPUT_UPDATE1).xml
 	$(info RFC rendering has been tested with mmark version 2.2.8 and xml2rfc 2.46.0, please ensure these are installed and recent enough.)
 
 $(OUTPUT).md: specification.markdown rfc_frontmatter.markdown rfc_backmatter.markdown EBMLSchema8794.xsd ebml_schema_example.xml
 	cat rfc_frontmatter.markdown $< rfc_backmatter.markdown | sed "s/@BUILD_DATE@/$(shell date +'%F')/" > $(OUTPUT).md
+
+$(OUTPUT_UPDATE1).md: update1/update1_frontmatter.markdown update1/update1.markdown update1/update1_backmatter.markdown EBMLSchema.xsd
+	cat update1/update1_frontmatter.markdown update1/update1.markdown update1/update1_backmatter.markdown | sed -e "s/@BUILD_DATE@/$(shell date +'%F')/" \
+	             -e "s/@BUILD_VERSION@/$(OUTPUT_UPDATE1)/" > $@
 
 %.xml: %.md
 	$(MMARK) $< > $@
@@ -34,11 +40,12 @@ rfc8794.xml: $(OUTPUT).xml
 	-e 's@<back>@<back>\n<displayreference target="I-D.ietf-cellar-matroska" to="Matroska"/>@' \
 	$< > $@
 
-%.html: rfc8794.xml
+%.html: %.xml
 	$(XML2RFC) --html $< -o $@
 
-%.txt: rfc8794.xml
+%.txt: %.xml
 	$(XML2RFC) $< -o $@
 
 clean:
 	rm -f $(OUTPUT).txt $(OUTPUT).html $(OUTPUT).md $(OUTPUT).xml
+	rm -f $(OUTPUT_UPDATE1).txt $(OUTPUT_UPDATE1).html $(OUTPUT_UPDATE1).md $(OUTPUT_UPDATE1).xml

--- a/specification.markdown
+++ b/specification.markdown
@@ -1195,7 +1195,7 @@ The following provides an XML Schema [@!XML-SCHEMA] for
 facilitating verification of an EBML Schema described in
 (#ebml-schema).
 
-<{{EBMLSchema.xsd}}
+<{{EBMLSchema8794.xsd}}
 
 ### Identically Recurring Elements
 

--- a/specification.markdown
+++ b/specification.markdown
@@ -41,7 +41,7 @@ The key words "**MUST**", "**MUST NOT**",
 "**SHOULD**", "**SHOULD NOT**",
 "**RECOMMENDED**", "**NOT RECOMMENDED**",
 "**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
-described in BCP 14 [@!RFC2119] [@!RFC8174] 
+described in BCP 14 [@!RFC2119] [@!RFC8174]
 when, and only when, they appear in all capitals, as shown here.
 
 This document defines specific terms in order to define the format and
@@ -51,7 +51,7 @@ application of `EBML`. Specific terms are defined below:
 : Extensible Binary Meta Language
 
 `EBML Document Type`:
-: A name provided by an `EBML Schema` to designate a particular 
+: A name provided by an `EBML Schema` to designate a particular
 implementation of `EBML` for a data format (e.g., Matroska and WebM).
 
 `EBML Schema`:
@@ -165,19 +165,19 @@ The Element ID and Element Data Size are both encoded as a Variable-Size
 Integer. The Variable-Size Integer is composed of a VINT\_WIDTH, VINT\_MARKER,
 and VINT\_DATA, in that order. Variable-Size Integers **MUST**
 left-pad the VINT\_DATA value with zero bits so that the whole Variable-Size
-Integer is octet aligned. The Variable-Size Integer will be referred to as 
+Integer is octet aligned. The Variable-Size Integer will be referred to as
 VINT for shorthand.
 
 ## VINT_WIDTH
 
 Each Variable-Size Integer starts with a VINT\_WIDTH followed by a
 VINT\_MARKER. VINT\_WIDTH is a sequence of zero or more bits of value `0`
-and is terminated by the VINT\_MARKER, which is a single bit of value 
-`1`. The total length in bits of both VINT\_WIDTH and VINT\_MARKER is the 
+and is terminated by the VINT\_MARKER, which is a single bit of value
+`1`. The total length in bits of both VINT\_WIDTH and VINT\_MARKER is the
 total length in octets in of the Variable-Size Integer.
 
 The single bit `1` starts a Variable-Size Integer with a length of
-one octet. The sequence of bits `01` starts a Variable-Size Integer 
+one octet. The sequence of bits `01` starts a Variable-Size Integer
 with a length of two octets. `001` starts a Variable-Size Integer with
 a length of three octets, and so on, with each additional `0` bit adding one
 octet to the length of the Variable-Size Integer.
@@ -189,14 +189,14 @@ The VINT\_MARKER serves as a separator between the VINT\_WIDTH and VINT\_DATA. E
 ## VINT_DATA
 
 The VINT\_DATA portion of the Variable-Size Integer includes all data following
-(but not including) the VINT\_MARKER until end of the Variable-Size 
+(but not including) the VINT\_MARKER until end of the Variable-Size
 Integer whose length is derived from the VINT\_WIDTH. The bits required for the
 VINT\_WIDTH and the VINT\_MARKER use one out of every eight bits of the total
 length of the Variable-Size Integer. Thus, a Variable-Size Integer of 1-octet
 length supplies 7 bits for VINT\_DATA, a 2-octet length supplies 14 bits for
 VINT\_DATA, and a 3-octet length supplies 21 bits for VINT\_DATA. If the number
 of bits required for VINT\_DATA is less than the bit size of VINT\_DATA, then
-VINT\_DATA **MUST** be zero-padded to the left to a size that 
+VINT\_DATA **MUST** be zero-padded to the left to a size that
 fits. The VINT\_DATA value **MUST** be expressed as a big-endian
 unsigned integer.
 
@@ -218,10 +218,10 @@ Octet Length | Usable Bits | Representation
 5            | 35          | 0000 1xxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx xxxx
 Table: VINT examples depicting usable bits{#tableUsableBits}
 
-A Variable-Size Integer may be rendered at octet lengths larger 
+A Variable-Size Integer may be rendered at octet lengths larger
 than needed to store the data in order to facilitate overwriting it at a later
 date -- e.g., when its final size isn't known in advance. In
-[@tableVariousSizes], an integer `2` (with a 
+[@tableVariousSizes], an integer `2` (with a
 corresponding binary value of 0b10) is shown encoded as different Variable-Size
 Integers with lengths from one octet to four octets. All four encoded
 examples have identical semantic meaning, though the VINT\_WIDTH and the padding
@@ -244,7 +244,7 @@ one octet to four octets in length, although Element IDs of greater lengths
 is set to a value greater than four (see
 (#ebmlmaxidlength-element)). The bits of the VINT\_DATA component
 of the Element ID **MUST NOT** be all
- `1` values. The VINT\_DATA component of the Element ID 
+ `1` values. The VINT\_DATA component of the Element ID
 **MUST** be encoded at the shortest valid length. For example, an
 Element ID with binary encoding of `1011 1111` is valid, whereas an
 Element ID with binary encoding of `0100 0000 0011 1111` stores a
@@ -252,7 +252,7 @@ semantically equal VINT\_DATA but is invalid, because a shorter VINT encoding is
 possible. Additionally, an Element ID with binary encoding of `1111 1111`
 is invalid, since the VINT\_DATA section is set to all one values,
 whereas an Element ID with binary encoding of `0100 0000 0111 1111`
-stores a semantically equal VINT\_DATA and is the shortest-possible VINT 
+stores a semantically equal VINT\_DATA and is the shortest-possible VINT
 encoding.
 
 [@tableElementIDValidity] details these specific examples further:
@@ -279,18 +279,18 @@ Element ID Octet Length | Range of Valid Element IDs   | Number of Valid Element
 2                       |     0x407F - 0x7FFE          |        16,256
 3                       |   0x203FFF - 0x3FFFFE        |     2,080,768
 4                       | 0x101FFFFF - 0x1FFFFFFE      |   268,338,304
-Table: Examples of count and range for 
+Table: Examples of count and range for
 Element IDs at various octet lengths{#tableElementIDRanges}
 
 # Element Data Size
 
 ## Data Size Format
 
-The Element Data Size expresses the length in octets of Element Data. The 
+The Element Data Size expresses the length in octets of Element Data. The
 Element Data Size itself is encoded as a Variable-Size Integer. By default,
 Element Data Sizes can be encoded in lengths from one octet to eight octets,
 although Element Data Sizes of greater lengths **MAY** be used if
-the octet length of the longest Element Data Size of the EBML Document is 
+the octet length of the longest Element Data Size of the EBML Document is
 declared in the EBMLMaxSizeLength Element of the EBML Header (see
 (#ebmlmaxsizelength-element)). Unlike the VINT\_DATA of the
 Element ID, the VINT\_DATA component of the Element Data Size is not mandated
@@ -306,7 +306,7 @@ Element Types that do not mandate a nonzero length (see
 (#ebml-element-types)). An Element Data Size with all VINT\_DATA
 bits set to zero indicates that the Element Data is zero octets in
 length. Such an EBML Element is referred to as an Empty Element. If an Empty
-Element has a default value declared, then the EBML Reader **MUST** 
+Element has a default value declared, then the EBML Reader **MUST**
 interpret the value of the Empty Element as the default value. If an Empty
 Element has no default value declared, then the EBML Reader **MUST**
 use the value of the Empty Element for the corresponding EBML Element Type of
@@ -353,7 +353,7 @@ Table: Examples of determining the end of an Unknown-Sized Element
 ## Data Size Values
 
 For Element Data Sizes encoded at octet lengths from one to eight,
-[@tableVintRangePerLength] depicts the range of possible values 
+[@tableVintRangePerLength] depicts the range of possible values
 that can be encoded as an Element Data Size. An Element Data Size with an
 octet length of 8 is able to express a size of 2^(56)^-2 or
 72,057,594,037,927,934 octets (or about 72 petabytes). The maximum possible
@@ -372,7 +372,7 @@ Octet Length | Possible Value Range
 Table: Possible range of values that
 can be stored in VINTs, by octet length{#tableVintRangePerLength}
 
-If the length of Element Data equals 2^n\*7^-1, then the octet 
+If the length of Element Data equals 2^n\*7^-1, then the octet
 length of the Element Data Size **MUST** be at least n+1. This rule
 prevents an Element Data Size from being expressed as the unknown-size
 value. [@tableVintReservation] clarifies this rule by
@@ -499,7 +499,7 @@ All data of an EBML Document following the EBML Header is the EBML Body. The end
 
 Within the EBML Body, the maximum octet length allowed for any Element ID
 is set by the EBMLMaxIDLength Element of the EBML Header, and the maximum octet
-length allowed for any Element Data Size is set by the EBMLMaxSizeLength 
+length allowed for any Element Data Size is set by the EBMLMaxSizeLength
 Element of the EBML Header.
 
 # EBML Stream
@@ -888,7 +888,7 @@ nonnegative integer or a range (see
 integers and valid operators.
 
 The `length` attribute is **OPTIONAL**. If the
-`length` attribute is 
+`length` attribute is
 not present for that EBML Element, then that EBML Element is only limited in
 length by the definition of the associated EBML Element Type.
 
@@ -945,11 +945,11 @@ This attribute is a boolean to express whether an EBML Element is permitted to
 be stored recursively. If it is allowed, the EBML Element **MAY** be
 stored within another EBML Element that has the same Element ID, which itself
 can be stored in an EBML Element that has the same Element ID, and so on. EBML
-Elements that are not Master Elements **MUST NOT** set recursive to 
+Elements that are not Master Elements **MUST NOT** set recursive to
 true.
 
 If the EBMLElement part of the `@path` contains an IsRecursive part,
-then the `recursive` value **MUST** be true; otherwise, it 
+then the `recursive` value **MUST** be true; otherwise, it
 **MUST** be false.
 
 An EBML Element with the `recursive` attribute set to 1 **MUST NOT**
@@ -1277,7 +1277,7 @@ value, and/or the Parent Element is used.
 | Yes               | No                      | No                   | No                                         |
 | No                | n/a                     | Yes                  | Yes                                        |
 | No                | n/a                     | No                   | No                                         |
-Table: Demonstration of the conditional 
+Table: Demonstration of the conditional
 requirements of VINT Storage{#tableVintRequirements}
 
 ## EBML Header Elements
@@ -1814,7 +1814,7 @@ Status | Element ID | Element Data Size | Element Data | Void Element
 -------|------------|-------------------|--------------|-------------
 Before | 0x3B4040   | 0x4003            | 0x6D6B76     |
 After  | 0x3B4040   | 0x82              | 0x6869       | 0xEC80
-Table: Example of editing a 
+Table: Example of editing a
 VINT to reduce VINT_DATA length by more than one octet{#tableShortenVintMoreThanOneOctet}
 
 ### Terminating Element Data
@@ -1962,7 +1962,7 @@ and 0x1FFFFFFE. Four-octet Element IDs are somewhat special in that
 they are useful for resynchronizing to major structures in the event
 of data corruption or loss. As such, four-octet Element IDs are split
 into two categories. Four-octet Element IDs whose lower three octets
-(as encoded) would make printable 7-bit ASCII values (0x20 to 0x7E, 
+(as encoded) would make printable 7-bit ASCII values (0x20 to 0x7E,
 inclusive) **MUST** be allocated by the "Specification
 Required" policy. Sequential allocation of values is not
 required: specifications **SHOULD** include a specific

--- a/update1/update1.markdown
+++ b/update1/update1.markdown
@@ -1,0 +1,79 @@
+# Introduction
+
+EBML, short for Extensible Binary Meta Language, specifies a binary format
+aligned with octets (bytes) and inspired by the principle of XML (a framework for
+structuring data). It is defined in [@!RFC8794].
+
+When adding a new EBML Element to an EBML format certain attributes need to be set for that element.
+They are defined in the text version of the format specification
+and can also be defined in an EBML Schema.
+
+This document adds new attributes to the definition of an EBML Element.
+It allows gradually adding new elements that are backward compatible for a given
+`EBML DocType` version and distinguish between states of the specification at a given update version or date.
+
+# Notation and Conventions
+
+The key words "**MUST**", "**MUST NOT**",
+"**REQUIRED**", "**SHALL**", "**SHALL NOT**",
+"**SHOULD**", "**SHOULD NOT**",
+"**RECOMMENDED**", "**NOT RECOMMENDED**",
+"**MAY**", and "**OPTIONAL**" in this document are to be interpreted as
+described in BCP 14 [@!RFC2119] [@!RFC8174]
+when, and only when, they appear in all capitals, as shown here.
+
+# New `<EBMLSchema>` Attributes
+
+## update Attribute
+
+A new attribute is added to the list of attributes found in [@?RFC8794, section 11.1.4].
+
+Within an EBML Schema, the XPath of the new `@update` attribute is `/EBMLSchema/@update`.
+
+`update` is a nonnegative integer expressing the update version in which a given element was added to the EBML Schema of an `EBML DocType`.
+
+The syntax of the `update` values is defined using this Augmented Backus-Naur Form (ABNF) [@!RFC5234] notation:
+
+```abnf
+update           = 1*DIGIT
+```
+
+The `update` attribute is **OPTIONAL** within the <EBMLSchema> Element and the EBML Element text definition.
+If the `update` attribute is not present the element is considered to have always
+been present in `minver` [@!RFC8794, section 11.1.6.13] version of the format it's defined for.
+
+## added Attribute
+
+A new attribute is added to the list of attributes found in [@?RFC8794, section 11.1.4].
+
+Within an EBML Schema, the XPath of the new `@added` attribute is `/EBMLSchema/@added`.
+
+`added` is a nonnegative integer expressing the date when a given element was added to the EBML Schema of an `EBML DocType`.
+The value is in the form "YYYYMMDD" where YYYY represents the year similar to the `date-fullyear` in [@!RFC3339, section 5.6],
+"MM" represents the month similar to the `date-month` in [@!RFC3339, section 5.6],
+and "DD" represents the month similar to the `date-mday` in [@!RFC3339, section 5.6].
+
+The "-" separator is not included for easier comparison in XSLT.
+
+The syntax of the `added` values is defined using this Augmented Backus-Naur Form (ABNF) [@!RFC5234] notation:
+
+```abnf
+date-fullyear   = 4DIGIT
+date-month      = 2DIGIT  ; 01-12
+date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+                          ; month/year
+
+added           = date-fullyear date-month date-mday
+```
+
+The `added` attribute is **OPTIONAL** within the <EBMLSchema> Element and the EBML Element text definition.
+If the `added` attribute is not present the element is considered to have always
+been present in `minver` [@!RFC8794, section 11.1.6.13] version of the format it's defined for.
+
+# Updated EBML Schema
+
+The following provides the updated XML Schema [@!XML-SCHEMA] of the EBML Schema
+found in [@!RFC8794, section 11.1.16].
+
+<{{EBMLSchema.xsd}}
+

--- a/update1/update1_backmatter.markdown
+++ b/update1/update1_backmatter.markdown
@@ -1,0 +1,17 @@
+
+{backmatter}
+
+<reference anchor="XML-SCHEMA" target="https://www.w3.org/TR/2004/REC-xmlschema-0-20041028/">
+     <front>
+       <title>XML Schema Part 0: Primer Second Edition</title>
+       <author initials="D.C." surname="Fallside" fullname="David C. Fallside">
+         <organization />
+       </author>
+       <author initials="P" surname="Walmsley" fullname="Priscilla Walmsley">
+         <organization />
+       </author>
+       <date year="2004" month="October" day="28"/>
+     </front>
+     <seriesInfo name="W3C" value="Recommendation" />
+     <seriesInfo name="Latest version available at" value="http://www.w3.org/TR/xmlschema-0/" />
+</reference>

--- a/update1/update1_frontmatter.markdown
+++ b/update1/update1_frontmatter.markdown
@@ -1,0 +1,30 @@
+%%%
+title = "Extensible Binary Meta Language Schema update"
+abbrev = "EBML"
+ipr= "trust200902"
+area = "art"
+submissiontype = "IETF"
+workgroup = "cellar"
+date = @BUILD_DATE@
+keyword = ["binary","storage","xml","ebml","matroska","webm"]
+updates = [ 8794 ]
+
+[seriesInfo]
+name = "Internet-Draft"
+stream = "IETF"
+status = "standard"
+value = "@BUILD_VERSION@"
+
+[[author]]
+initials="S."
+surname="Lhomme"
+fullname="Steve Lhomme"
+  [author.address]
+  email="slhomme@matroska.org"
+%%%
+
+.# Abstract
+
+This document adds new attributes to the Extensible Binary Meta Language (EBML) element definitions.
+
+{mainmatter}


### PR DESCRIPTION
So we can keep using the same `minver` version and distinguish elements between version of a specficiations.

We could also name it "revision" and use incremental values between published versions.
It carries less information than `added` but allows clean distinction of document/spec updates.